### PR TITLE
Add MatFormer manifest support for tier-sliced checkpoints

### DIFF
--- a/scripts/export_matformer_tiers.py
+++ b/scripts/export_matformer_tiers.py
@@ -11,17 +11,29 @@ This will write checkpoints/matformer-test-tier1 and -tier2 with:
 - matformer_base_intermediate_size recorded for auto-detection
 - sliced safetensors (single-shard only)
 - tokenizer and auxiliary json files copied over
+- matformer_manifest.json in the source directory describing tier files
 """
 from __future__ import annotations
 
 import argparse
 import json
 import shutil
+from hashlib import sha256
+from os.path import relpath
 from pathlib import Path
 from typing import Iterable
 
 import torch
 from safetensors.torch import load_file, save_file
+
+COMMON_PATTERNS = (
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "special_tokens_map.json",
+    "generation_config.json",
+    "*.py",
+)
+MANIFEST_NAME = "matformer_manifest.json"
 
 
 def find_single_safetensors(src: Path) -> Path:
@@ -49,6 +61,88 @@ def slice_ffn_weights(weights: dict[str, torch.Tensor], divisor: int) -> dict[st
     return sliced
 
 
+def collect_weight_files(root: Path) -> list[Path]:
+    weights = sorted(root.glob("*.safetensors"))
+    weights += sorted(root.glob("*.safetensors.index.json"))
+    return [p for p in weights if p.is_file()]
+
+
+def collect_common_files(root: Path) -> list[Path]:
+    files: list[Path] = []
+    for pattern in COMMON_PATTERNS:
+        files.extend(sorted(root.glob(pattern)))
+    return [p for p in files if p.is_file()]
+
+
+def rel_to_manifest(path: Path, manifest_dir: Path) -> str:
+    return Path(relpath(path, start=manifest_dir)).as_posix()
+
+
+def file_sha256(path: Path) -> str:
+    hasher = sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def write_manifest(
+    manifest_dir: Path,
+    base_intermediate_size: int,
+    tiers: Iterable[int],
+) -> None:
+    manifest_path = manifest_dir / MANIFEST_NAME
+    common_files = collect_common_files(manifest_dir)
+    common_rel = [rel_to_manifest(path, manifest_dir) for path in common_files]
+
+    tier_entries: list[dict[str, object]] = []
+    sha_map: dict[str, str] = {}
+
+    for path in common_files:
+        sha_map[rel_to_manifest(path, manifest_dir)] = file_sha256(path)
+
+    # Tier 0 entry (universal checkpoint)
+    base_files = [manifest_dir / "config.json"] + collect_weight_files(manifest_dir)
+    base_files = [p for p in base_files if p.is_file()]
+    base_rel = [rel_to_manifest(path, manifest_dir) for path in base_files]
+    for path in base_files:
+        sha_map[rel_to_manifest(path, manifest_dir)] = file_sha256(path)
+    tier_entries.append(
+        {
+            "tier": 0,
+            "intermediate_size": base_intermediate_size,
+            "files": base_rel,
+        }
+    )
+
+    for tier in tiers:
+        tier_dir = manifest_dir.with_name(f"{manifest_dir.name}-tier{tier}")
+        tier_config = tier_dir / "config.json"
+        if not tier_config.is_file():
+            raise FileNotFoundError(f"tier {tier} config.json missing at {tier_config}")
+        tier_files = [tier_config] + collect_weight_files(tier_dir)
+        tier_files = [p for p in tier_files if p.is_file()]
+        tier_rel = [rel_to_manifest(path, manifest_dir) for path in tier_files]
+        for path in tier_files:
+            sha_map[rel_to_manifest(path, manifest_dir)] = file_sha256(path)
+        tier_entries.append(
+            {
+                "tier": tier,
+                "intermediate_size": base_intermediate_size // (1 << tier),
+                "files": tier_rel,
+            }
+        )
+
+    manifest = {
+        "schema_version": 1,
+        "matformer_base_intermediate_size": base_intermediate_size,
+        "common_files": common_rel,
+        "tiers": tier_entries,
+        "sha256": sha_map,
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2))
+
+
 def export_tier(src: Path, tier: int) -> Path:
     if tier < 1:
         raise ValueError("tier must be >=1 for slicing")
@@ -63,7 +157,9 @@ def export_tier(src: Path, tier: int) -> Path:
     if config.get("matformer_tier", 0) not in (0, None):
         raise ValueError("source checkpoint appears tier-sliced; expected universal checkpoint")
     divisor = 1 << tier
-    base_intermediate_size = config.get("matformer_base_intermediate_size", config["intermediate_size"])
+    base_intermediate_size = config.get(
+        "matformer_base_intermediate_size", config["intermediate_size"]
+    )
     config["intermediate_size"] = base_intermediate_size // divisor
     config["matformer_tier"] = tier
     config["matformer_base_intermediate_size"] = base_intermediate_size
@@ -104,9 +200,19 @@ def main() -> None:
     src: Path = args.src
     tiers: Iterable[int] = args.tiers
 
+    config = json.loads((src / "config.json").read_text())
+    if "intermediate_size" not in config:
+        raise ValueError("config.json missing intermediate_size")
+    base_intermediate_size = config.get(
+        "matformer_base_intermediate_size", config["intermediate_size"]
+    )
+
     for tier in tiers:
         dst = export_tier(src, tier)
         print(f"[export] wrote {dst}")
+
+    write_manifest(src, base_intermediate_size, tiers)
+    print(f"[export] wrote {src / MANIFEST_NAME}")
 
 
 if __name__ == "__main__":

--- a/shared/client/src/lib.rs
+++ b/shared/client/src/lib.rs
@@ -1,6 +1,7 @@
 mod cli;
 mod client;
 mod fetch_data;
+pub mod matformer;
 mod protocol;
 mod state;
 mod testing;

--- a/shared/client/src/matformer.rs
+++ b/shared/client/src/matformer.rs
@@ -1,0 +1,174 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
+
+pub const MATFORMER_MANIFEST_NAME: &str = "matformer_manifest.json";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MatformerCheckpointMetadata {
+    pub tier: Option<u8>,
+    pub base_intermediate_size: Option<u64>,
+}
+
+pub fn infer_matformer_checkpoint_metadata(config: &Value) -> MatformerCheckpointMetadata {
+    let intermediate_size = config.get("intermediate_size").and_then(|v| v.as_u64());
+
+    if let Some(tier) = config.get("matformer_tier").and_then(|v| v.as_u64()) {
+        let base_size = config
+            .get("matformer_base_intermediate_size")
+            .and_then(|v| v.as_u64())
+            .or_else(|| intermediate_size.and_then(|size| size.checked_shl(tier as u32)));
+        return MatformerCheckpointMetadata {
+            tier: Some(tier as u8),
+            base_intermediate_size: base_size,
+        };
+    }
+
+    if let (Some(base), Some(current)) = (
+        config.get("matformer_base_intermediate_size").and_then(|v| v.as_u64()),
+        intermediate_size,
+    ) {
+        if let Some(tier) = compute_tier_from_sizes(base, current) {
+            return MatformerCheckpointMetadata {
+                tier: Some(tier),
+                base_intermediate_size: Some(base),
+            };
+        }
+    }
+
+    MatformerCheckpointMetadata {
+        tier: None,
+        base_intermediate_size: intermediate_size,
+    }
+}
+
+pub fn annotate_matformer_checkpoint_config(
+    config: &mut Value,
+    base_intermediate_size_override: Option<u64>,
+) -> MatformerCheckpointMetadata {
+    let intermediate_size = config.get("intermediate_size").and_then(|v| v.as_u64());
+    let base_size = base_intermediate_size_override
+        .or_else(|| {
+            config
+                .get("matformer_base_intermediate_size")
+                .and_then(|v| v.as_u64())
+        })
+        .or(intermediate_size);
+
+    let tier = match (base_size, intermediate_size) {
+        (Some(base), Some(current)) => compute_tier_from_sizes(base, current).unwrap_or(0),
+        _ => 0,
+    };
+
+    if let Some(obj) = config.as_object_mut() {
+        obj.insert("matformer_tier".to_string(), Value::from(tier));
+        if let Some(base_size) = base_size {
+            obj.insert(
+                "matformer_base_intermediate_size".to_string(),
+                Value::from(base_size),
+            );
+        }
+    }
+
+    MatformerCheckpointMetadata {
+        tier: Some(tier),
+        base_intermediate_size: base_size,
+    }
+}
+
+fn compute_tier_from_sizes(base: u64, current: u64) -> Option<u8> {
+    if base == 0 || current == 0 || base < current {
+        return None;
+    }
+    let ratio = base / current;
+    if ratio.is_power_of_two() {
+        Some(ratio.trailing_zeros() as u8)
+    } else {
+        None
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MatformerManifest {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub matformer_base_intermediate_size: Option<u64>,
+    #[serde(default)]
+    pub common_files: Vec<String>,
+    #[serde(default)]
+    pub tiers: Vec<MatformerManifestTier>,
+    #[serde(default)]
+    pub sha256: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MatformerManifestTier {
+    pub tier: u8,
+    #[serde(default)]
+    pub intermediate_size: Option<u64>,
+    #[serde(default)]
+    pub files: Vec<String>,
+}
+
+impl MatformerManifest {
+    pub fn available_tiers(&self) -> Vec<u8> {
+        let mut tiers = self.tiers.iter().map(|entry| entry.tier).collect::<Vec<_>>();
+        tiers.sort_unstable();
+        tiers.dedup();
+        tiers
+    }
+
+    pub fn tier_entry(&self, tier: u8) -> Option<&MatformerManifestTier> {
+        self.tiers.iter().find(|entry| entry.tier == tier)
+    }
+
+    pub fn files_for_tier(&self, tier: u8) -> Option<Vec<String>> {
+        let entry = self.tier_entry(tier)?;
+        let mut seen = HashSet::new();
+        let mut files = Vec::new();
+        for name in self
+            .common_files
+            .iter()
+            .chain(entry.files.iter())
+        {
+            if seen.insert(name) {
+                files.push(name.clone());
+            }
+        }
+        Some(files)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_files_for_tier_combines_common_and_tier_files() {
+        let manifest = MatformerManifest {
+            schema_version: 1,
+            matformer_base_intermediate_size: Some(1024),
+            common_files: vec!["tokenizer.json".to_string(), "shared.py".to_string()],
+            tiers: vec![MatformerManifestTier {
+                tier: 1,
+                intermediate_size: Some(512),
+                files: vec![
+                    "../model-tier1/config.json".to_string(),
+                    "../model-tier1/model.safetensors".to_string(),
+                ],
+            }],
+            sha256: HashMap::new(),
+        };
+
+        let files = manifest.files_for_tier(1).unwrap();
+        assert_eq!(
+            files,
+            vec![
+                "tokenizer.json".to_string(),
+                "shared.py".to_string(),
+                "../model-tier1/config.json".to_string(),
+                "../model-tier1/model.safetensors".to_string(),
+            ]
+        );
+    }
+}

--- a/shared/client/src/state/init.rs
+++ b/shared/client/src/state/init.rs
@@ -391,11 +391,13 @@ async fn resolve_matformer_local_repo_path(
     }
 }
 
+#[derive(Debug)]
 struct ManifestSelection {
     files: Vec<String>,
     config_path: String,
 }
 
+#[derive(Debug)]
 struct ResolvedRepoFiles {
     repo_files: Vec<PathBuf>,
     uses_sliced_checkpoint: bool,

--- a/shared/client/tests/matformer_metadata.rs
+++ b/shared/client/tests/matformer_metadata.rs
@@ -1,5 +1,6 @@
 use psyche_client::matformer::{
-    annotate_matformer_checkpoint_config, infer_matformer_checkpoint_metadata,
+    annotate_matformer_checkpoint_config, ensure_matformer_checkpoint_metadata,
+    infer_matformer_checkpoint_metadata,
 };
 use serde_json::json;
 
@@ -36,6 +37,17 @@ fn infer_metadata_without_matformer_fields() {
 }
 
 #[test]
+fn infer_metadata_rejects_non_divisible_ratio() {
+    let config = json!({
+        "intermediate_size": 600,
+        "matformer_base_intermediate_size": 1000,
+    });
+    let metadata = infer_matformer_checkpoint_metadata(&config);
+    assert_eq!(metadata.tier, None);
+    assert_eq!(metadata.base_intermediate_size, Some(1000));
+}
+
+#[test]
 fn annotate_config_sets_tier_and_base_size() {
     let mut config = json!({
         "intermediate_size": 512,
@@ -60,4 +72,42 @@ fn annotate_config_respects_existing_base_size() {
     assert_eq!(config["matformer_tier"], 1);
     assert_eq!(config["matformer_base_intermediate_size"], 1024);
     assert_eq!(config["intermediate_size"], 512);
+}
+
+#[test]
+fn ensure_metadata_uses_manifest_base_size() {
+    let mut config = json!({
+        "intermediate_size": 512,
+    });
+    let metadata = ensure_matformer_checkpoint_metadata(&mut config, Some(1024), None);
+    assert_eq!(metadata.tier, Some(1));
+    assert_eq!(metadata.base_intermediate_size, Some(1024));
+    assert_eq!(config["matformer_tier"], 1);
+    assert_eq!(config["matformer_base_intermediate_size"], 1024);
+}
+
+#[test]
+fn ensure_metadata_uses_slice_tier_hint() {
+    let mut config = json!({
+        "intermediate_size": 256,
+    });
+    let metadata = ensure_matformer_checkpoint_metadata(&mut config, None, Some(2));
+    assert_eq!(metadata.tier, Some(2));
+    assert_eq!(metadata.base_intermediate_size, Some(1024));
+    assert_eq!(config["matformer_tier"], 2);
+    assert_eq!(config["matformer_base_intermediate_size"], 1024);
+}
+
+#[test]
+fn ensure_metadata_respects_existing_fields() {
+    let mut config = json!({
+        "intermediate_size": 512,
+        "matformer_tier": 2,
+        "matformer_base_intermediate_size": 2048,
+    });
+    let metadata = ensure_matformer_checkpoint_metadata(&mut config, Some(1024), Some(1));
+    assert_eq!(metadata.tier, Some(2));
+    assert_eq!(metadata.base_intermediate_size, Some(2048));
+    assert_eq!(config["matformer_tier"], 2);
+    assert_eq!(config["matformer_base_intermediate_size"], 2048);
 }

--- a/shared/client/tests/matformer_metadata.rs
+++ b/shared/client/tests/matformer_metadata.rs
@@ -1,0 +1,63 @@
+use psyche_client::matformer::{
+    annotate_matformer_checkpoint_config, infer_matformer_checkpoint_metadata,
+};
+use serde_json::json;
+
+#[test]
+fn infer_metadata_from_explicit_tier() {
+    let config = json!({
+        "intermediate_size": 512,
+        "matformer_tier": 1,
+    });
+    let metadata = infer_matformer_checkpoint_metadata(&config);
+    assert_eq!(metadata.tier, Some(1));
+    assert_eq!(metadata.base_intermediate_size, Some(1024));
+}
+
+#[test]
+fn infer_metadata_from_base_size() {
+    let config = json!({
+        "intermediate_size": 512,
+        "matformer_base_intermediate_size": 1024,
+    });
+    let metadata = infer_matformer_checkpoint_metadata(&config);
+    assert_eq!(metadata.tier, Some(1));
+    assert_eq!(metadata.base_intermediate_size, Some(1024));
+}
+
+#[test]
+fn infer_metadata_without_matformer_fields() {
+    let config = json!({
+        "intermediate_size": 512,
+    });
+    let metadata = infer_matformer_checkpoint_metadata(&config);
+    assert_eq!(metadata.tier, None);
+    assert_eq!(metadata.base_intermediate_size, Some(512));
+}
+
+#[test]
+fn annotate_config_sets_tier_and_base_size() {
+    let mut config = json!({
+        "intermediate_size": 512,
+    });
+    let metadata = annotate_matformer_checkpoint_config(&mut config, Some(1024));
+    assert_eq!(metadata.tier, Some(1));
+    assert_eq!(metadata.base_intermediate_size, Some(1024));
+    assert_eq!(config["matformer_tier"], 1);
+    assert_eq!(config["matformer_base_intermediate_size"], 1024);
+    assert_eq!(config["intermediate_size"], 512);
+}
+
+#[test]
+fn annotate_config_respects_existing_base_size() {
+    let mut config = json!({
+        "intermediate_size": 512,
+        "matformer_base_intermediate_size": 1024,
+    });
+    let metadata = annotate_matformer_checkpoint_config(&mut config, None);
+    assert_eq!(metadata.tier, Some(1));
+    assert_eq!(metadata.base_intermediate_size, Some(1024));
+    assert_eq!(config["matformer_tier"], 1);
+    assert_eq!(config["matformer_base_intermediate_size"], 1024);
+    assert_eq!(config["intermediate_size"], 512);
+}

--- a/shared/data-provider/src/hub.rs
+++ b/shared/data-provider/src/hub.rs
@@ -78,6 +78,46 @@ async fn download_repo_async(
     Ok(ret)
 }
 
+async fn list_repo_files_async(
+    repo: Repo,
+    cache: Option<PathBuf>,
+    token: Option<String>,
+    progress_bar: bool,
+) -> Result<Vec<String>, ApiError> {
+    let builder = hf_hub::api::tokio::ApiBuilder::new();
+    let cache = match cache {
+        Some(cache) => Cache::new(cache),
+        None => Cache::default(),
+    };
+    let api = builder
+        .with_cache_dir(cache.path().clone())
+        .with_token(token.or(cache.token()))
+        .with_progress(progress_bar)
+        .build()?
+        .repo(repo);
+    let siblings = api.info().await?.siblings;
+    Ok(siblings.into_iter().map(|s| s.rfilename).collect())
+}
+
+pub async fn list_model_repo_files_async(
+    repo_id: &str,
+    revision: Option<String>,
+    cache: Option<PathBuf>,
+    token: Option<String>,
+    progress_bar: bool,
+) -> Result<Vec<String>, ApiError> {
+    list_repo_files_async(
+        match revision {
+            Some(revision) => Repo::with_revision(repo_id.to_string(), RepoType::Model, revision),
+            None => Repo::model(repo_id.to_string()),
+        },
+        cache,
+        token,
+        progress_bar,
+    )
+    .await
+}
+
 pub async fn download_model_repo_async(
     repo_id: &str,
     revision: Option<String>,
@@ -98,6 +138,61 @@ pub async fn download_model_repo_async(
         &MODEL_EXTENSIONS,
     )
     .await
+}
+
+pub async fn download_model_repo_files_async(
+    repo_id: &str,
+    revision: Option<String>,
+    cache: Option<PathBuf>,
+    token: Option<String>,
+    max_concurrent_downloads: Option<usize>,
+    progress_bar: bool,
+    files: &[String],
+) -> Result<Vec<PathBuf>, ApiError> {
+    if files.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let builder = hf_hub::api::tokio::ApiBuilder::new();
+    let cache = match cache {
+        Some(cache) => Cache::new(cache),
+        None => Cache::default(),
+    };
+    let api = builder
+        .with_cache_dir(cache.path().clone())
+        .with_token(token.or(cache.token()))
+        .with_progress(progress_bar)
+        .build()?
+        .repo(match revision {
+            Some(revision) => Repo::with_revision(repo_id.to_string(), RepoType::Model, revision),
+            None => Repo::model(repo_id.to_string()),
+        });
+
+    let chunk_size = max_concurrent_downloads.unwrap_or(files.len());
+    let mut ret: Vec<PathBuf> = Vec::with_capacity(files.len());
+    for chunk in files.chunks(chunk_size) {
+        let futures = chunk
+            .iter()
+            .map(|name| async {
+                let start_time = Instant::now();
+                tracing::debug!(filename = name, "Starting file download from hub");
+                let res = api.get(name).await;
+                if res.is_ok() {
+                    let duration_secs = (Instant::now() - start_time).as_secs_f32();
+                    tracing::info!(
+                        filename = name,
+                        duration_secs = duration_secs,
+                        "Finished downloading file from hub"
+                    );
+                }
+                res
+            })
+            .collect::<Vec<_>>();
+        for future in futures {
+            ret.push(future.await?);
+        }
+    }
+    Ok(ret)
 }
 
 pub async fn download_dataset_repo_async(

--- a/shared/data-provider/src/lib.rs
+++ b/shared/data-provider/src/lib.rs
@@ -16,7 +16,8 @@ pub use dummy::DummyDataProvider;
 pub use file_extensions::{DATA_FILE_EXTENSIONS, PARQUET_EXTENSION};
 pub use hub::{
     UploadModelError, download_dataset_repo_async, download_dataset_repo_sync,
-    download_model_repo_async, download_model_repo_sync, upload_model_repo_async,
+    download_model_repo_async, download_model_repo_files_async, download_model_repo_sync,
+    list_model_repo_files_async, upload_model_repo_async,
 };
 pub use local::{DataFormat, LocalDataProvider};
 pub use parquet::record::{ListAccessor, MapAccessor, RowAccessor};


### PR DESCRIPTION
## Summary\n- add a MatFormer manifest schema with helpers for tier metadata\n- export manifests alongside tier-sliced checkpoints\n- resolve tier slices from local paths or HF via manifest, with strict errors/fallbacks\n- normalize schema hashing across sliced/full checkpoints\n\n## Testing\n- not run (branch adds unit tests for manifest + metadata)\n\nCloses #10